### PR TITLE
Invert bits to render correctly on browsers which do not render whitespace character correctly

### DIFF
--- a/snake.js
+++ b/snake.js
@@ -242,6 +242,10 @@ function gridString() {
       | bitAt(x + 1, 2) << 5
       | bitAt(x, 3) << 6
       | bitAt(x + 1, 3) << 7;
+
+    // flip all 8 bits (invert full ↔ empty)
+    n = 0xFF ^ n;
+
     str += String.fromCharCode(0x2800 + n);
   }
   return str;


### PR DESCRIPTION
https://github.com/user-attachments/assets/dba3ea6c-5e2a-4592-86ca-9233dbe2cbc5

This update inverts the bits so that dots are used for the game's background and empty space is used for the player and the target object (food?). This allows the game to render correctly on browsers which do not render the whitespace character correctly (which seems to be most browsers lol)